### PR TITLE
service tests without database

### DIFF
--- a/src/test/java/com/footbalmanager/app/service/LeagueServiceImplTest.java
+++ b/src/test/java/com/footbalmanager/app/service/LeagueServiceImplTest.java
@@ -1,27 +1,38 @@
 package com.footbalmanager.app.service;
 
+import java.util.Arrays;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.junit4.SpringRunner;
 
 import com.footbalmanager.app.domain.League;
 import com.footbalmanager.app.domain.Season;
 import com.footbalmanager.app.repository.LeagueRepository;
 import com.footbalmanager.app.services.LeagueService;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.context.junit4.SpringRunner;
-
-import java.util.Arrays;
+import com.footbalmanager.app.services.LeagueServiceImpl;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest
 public class LeagueServiceImplTest {
+
+	@TestConfiguration
+	static class BaseServiceImplTestContextConfiguration {
+
+		@Bean
+		public LeagueService leagueService() {
+			return new LeagueServiceImpl();
+		}
+	}
+
     @MockBean
     private LeagueRepository leagueRepository;
     @Autowired

--- a/src/test/java/com/footbalmanager/app/service/MatchServiceImplTest.java
+++ b/src/test/java/com/footbalmanager/app/service/MatchServiceImplTest.java
@@ -1,28 +1,43 @@
 package com.footbalmanager.app.service;
 
+import java.util.Arrays;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.junit4.SpringRunner;
 
 import com.footbalmanager.app.domain.Match;
 import com.footbalmanager.app.domain.Team;
 import com.footbalmanager.app.repository.MatchRepository;
 import com.footbalmanager.app.services.MatchService;
+import com.footbalmanager.app.services.MatchServiceImpl;
 import com.footbalmanager.app.util.test.EntityTestManager;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.context.junit4.SpringRunner;
-
-import java.util.Arrays;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest
 public class MatchServiceImplTest {
+
+	@TestConfiguration
+	static class BaseServiceImplTestContextConfiguration {
+
+		@Bean
+		public MatchService matchService() {
+			return new MatchServiceImpl();
+		}
+
+		@Bean
+		public EntityTestManager entityTestManager() {
+			return new EntityTestManager();
+		}
+	}
 
     @MockBean
     private MatchRepository matchRepository;

--- a/src/test/java/com/footbalmanager/app/service/PlayerServiceImplTest.java
+++ b/src/test/java/com/footbalmanager/app/service/PlayerServiceImplTest.java
@@ -1,26 +1,36 @@
 package com.footbalmanager.app.service;
 
+import java.util.Arrays;
 
-import com.footbalmanager.app.domain.Player;
-import com.footbalmanager.app.repository.PlayerRepository;
-import com.footbalmanager.app.services.PlayerService;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import java.util.Arrays;
+import com.footbalmanager.app.domain.Player;
+import com.footbalmanager.app.repository.PlayerRepository;
+import com.footbalmanager.app.services.PlayerService;
+import com.footbalmanager.app.services.PlayerServiceImpl;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest
 public class PlayerServiceImplTest {
+
+	@TestConfiguration
+	static class BaseServiceImplTestContextConfiguration {
+
+		@Bean
+		public PlayerService playerService() {
+			return new PlayerServiceImpl();
+		}
+	}
 
     @MockBean
     private PlayerRepository playerRepository;

--- a/src/test/java/com/footbalmanager/app/service/SeasonServiceImplTest.java
+++ b/src/test/java/com/footbalmanager/app/service/SeasonServiceImplTest.java
@@ -1,26 +1,36 @@
 package com.footbalmanager.app.service;
 
+import java.util.Arrays;
 
-import com.footbalmanager.app.domain.Season;
-import com.footbalmanager.app.repository.SeasonRepository;
-import com.footbalmanager.app.services.SeasonService;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import java.util.Arrays;
+import com.footbalmanager.app.domain.Season;
+import com.footbalmanager.app.repository.SeasonRepository;
+import com.footbalmanager.app.services.SeasonService;
+import com.footbalmanager.app.services.SeasonServiceImpl;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest
 public class SeasonServiceImplTest {
+
+	@TestConfiguration
+	static class BaseServiceImplTestContextConfiguration {
+
+		@Bean
+		public SeasonService seasonService() {
+			return new SeasonServiceImpl();
+		}
+	}
 
     @MockBean
     private SeasonRepository seasonRepository;

--- a/src/test/java/com/footbalmanager/app/service/TeamServiceImplTest.java
+++ b/src/test/java/com/footbalmanager/app/service/TeamServiceImplTest.java
@@ -1,5 +1,16 @@
 package com.footbalmanager.app.service;
 
+import java.util.Arrays;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.BDDMockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.junit4.SpringRunner;
 
 import com.footbalmanager.app.domain.League;
 import com.footbalmanager.app.domain.Season;
@@ -7,23 +18,18 @@ import com.footbalmanager.app.domain.Team;
 import com.footbalmanager.app.repository.TeamRepository;
 import com.footbalmanager.app.services.TeamService;
 import com.footbalmanager.app.services.TeamServiceImpl;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.BDDMockito;
-import org.mockito.Mock;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Bean;
-import org.springframework.test.context.junit4.SpringRunner;
-
-import java.util.Arrays;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest
 public class TeamServiceImplTest {
+
+	@TestConfiguration
+	static class BaseServiceImplTestContextConfiguration {
+
+		@Bean
+		public TeamService teamService() {
+			return new TeamServiceImpl();
+		}
+	}
 
     @MockBean
     private TeamRepository teamRepository;


### PR DESCRIPTION
Po wywaleniu adnotacji @SpringBootTest w testach serwisów i ręcznej obsłudze wstrzykiwania implementacji beanów zarządzanych przez kontener springowy (przez blok statyczny) testy działają bez bazy danych. Do obejrzenia i zgłębienia tematu